### PR TITLE
Features/only 1 timer

### DIFF
--- a/examples/Autotest/Autotest.ino
+++ b/examples/Autotest/Autotest.ino
@@ -83,7 +83,7 @@ void setup()
 
 	DCCpp::begin();
 	// Configuration for my LMD18200. See the page 'Configuration lines' in the documentation for other samples.
-	DCCpp::beginMain(UNDEFINED_PIN, DCC_SIGNAL_PIN_MAIN, 11, A0);
+	DCCpp::beginMain(10, 11, A0);
 
 	DCCpp::powerOn();
 

--- a/examples/SerialDcc/SerialDcc.ino
+++ b/examples/SerialDcc/SerialDcc.ino
@@ -16,7 +16,7 @@ void setup()
 
 	DCCpp::begin();
 	// Configuration for my LMD18200. See the page 'Configuration lines' in the documentation for other samples.
-	DCCpp::beginMain(UNDEFINED_PIN, DCC_SIGNAL_PIN_MAIN, 11, A0);
+	DCCpp::beginMain(10, 11, A0);
 }
 
 void loop()

--- a/src/Config.h
+++ b/src/Config.h
@@ -90,15 +90,17 @@ struct DCCppConfig
 	static EthernetProtocol Protocol;
 #endif
 
+	static uint8_t SignalPortMaskMain;
+	static uint8_t SignalPortMaskProg;
+	static volatile uint8_t *SignalPortInMain;
+	static volatile uint8_t *SignalPortInProg;
+
 	static byte SignalEnablePinMain;	// PWM : *_SIGNAL_ENABLE_PIN_MAIN
 	static byte CurrentMonitorMain;		// Current sensor : *_CURRENT_MONITOR_PIN_MAIN
 
 	static byte SignalEnablePinProg;	// PWM : *_SIGNAL_ENABLE_PIN_PROG
 	static byte CurrentMonitorProg;		// Current sensor : *_CURRENT_MONITOR_PIN_PROG
 
-	// Only for shields : indirection of the signal from SignalPinMain to DirectionMotor of the shield
-	static byte DirectionMotorA;		// *_DIRECTION_MOTOR_CHANNEL_PIN_A
-	static byte DirectionMotorB;		// *_DIRECTION_MOTOR_CHANNEL_PIN_B
 };
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/src/Config.h
+++ b/src/Config.h
@@ -36,20 +36,6 @@ Part of DCC++ BASE STATION for the Arduino
 #endif
 #endif
 
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO)      // Configuration for UNO or NANO
-
-/** Interruption pin for main track.*/
-#define DCC_SIGNAL_PIN_MAIN 10          // Arduino Uno  - uses OC1B
-/** Interruption pin for programming track.*/
-#define DCC_SIGNAL_PIN_PROG 5           // Arduino Uno  - uses OC0B
-
-#elif defined(ARDUINO_AVR_MEGA2560)
-
-#define DCC_SIGNAL_PIN_MAIN 12          // Arduino Mega - uses OC1B
-#define DCC_SIGNAL_PIN_PROG 2           // Arduino Mega - uses OC3B
-
-#endif
-
 /////////////////////////////////////////////////////////////////////////////////////
 // SELECT MOTOR SHIELD
 /////////////////////////////////////////////////////////////////////////////////////

--- a/src/CurrentMonitor.cpp
+++ b/src/CurrentMonitor.cpp
@@ -28,9 +28,9 @@ void CurrentMonitor::begin(int pin, int inSignalPin, const char *msg, float inSa
   
 boolean CurrentMonitor::checkTime()
 {
-	if(millis( ) - sampleTime < CURRENT_SAMPLE_TIME)            // no need to check current yet
+	if(millis( ) - sampleTime < CURRENT_SAMPLE_TIME)   // no need to check current yet
 		return(false);
-	sampleTime = millis();                                   // note millis() uses TIMER-0.  For UNO, we change the scale on Timer-0.  For MEGA we do not.  This means CURENT_SAMPLE_TIME is different for UNO then MEGA
+	sampleTime = millis();  
 	return(true);  
 } // CurrentMonitor::checkTime
   
@@ -45,7 +45,7 @@ void CurrentMonitor::check()
 	if (this->current > this->currentSampleMax && digitalRead(this->signalPin) == HIGH)
 	{
 		digitalWrite(this->signalPin, LOW);
-		DCCPP_INTERFACE.print(this->msg);                                     // print corresponding error message
+		DCCPP_INTERFACE.print(this->msg);          // print corresponding error message
 #if !defined(USE_ETHERNET)
 		DCCPP_INTERFACE.println("");
 #endif

--- a/src/DCCpp.cpp
+++ b/src/DCCpp.cpp
@@ -114,10 +114,10 @@ void DCCpp::loop()
 #endif
 }
 
-void DCCpp::beginMain(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uint8_t inSignalEnable, uint8_t inCurrentMonitor)
+void DCCpp::beginMain(uint8_t inSignalPin, uint8_t inSignalEnable, uint8_t inCurrentMonitor)
 {
-	DCCppConfig::DirectionMotorA = inOptionalDirectionMotor;
-	DCCppConfig::SignalEnablePinMain = inSignalEnable;	// PWM
+	
+	DCCppConfig::SignalEnablePinMain = inSignalEnable;
 	DCCppConfig::CurrentMonitorMain = inCurrentMonitor;
 
 	// If no main line, exit.
@@ -131,47 +131,41 @@ void DCCpp::beginMain(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uin
 
 	mainMonitor.begin(DCCppConfig::CurrentMonitorMain, DCCppConfig::SignalEnablePinMain, (char *) "<p2>");
 
-	// CONFIGURE TIMER_1 TO OUTPUT 50% DUTY CYCLE DCC SIGNALS ON OC1B INTERRUPT PINS
-
-	// Direction Pin for Motor Shield Channel A - MAIN OPERATIONS TRACK
-	// Controlled by Arduino 16-bit TIMER 1 / OC1B Interrupt Pin
-	// Values for 16-bit OCR1A and OCR1B registers calibrated for 1:1 prescale at 16 MHz clock frequency
-	// Resulting waveforms are 200 microseconds for a ZERO bit and 116 microseconds for a ONE bit with exactly 50% duty cycle
-
-#define DCC_ZERO_BIT_TOTAL_DURATION_TIMER1 3199
-#define DCC_ZERO_BIT_PULSE_DURATION_TIMER1 1599
-
-#define DCC_ONE_BIT_TOTAL_DURATION_TIMER1 1855
-#define DCC_ONE_BIT_PULSE_DURATION_TIMER1 927
-	if (DCCppConfig::DirectionMotorA != UNDEFINED_PIN)
-	{
-		pinMode(DCCppConfig::DirectionMotorA, INPUT);      // ensure this pin is not active! Direction will be controlled by DCC SIGNAL instead (below)
-		digitalWrite(DCCppConfig::DirectionMotorA, LOW);
+	if (inSignalPin != UNDEFINED_PIN) {
+		pinMode(inSignalPin, OUTPUT); 
+		DCCppConfig::SignalPortMaskMain = digitalPinToBitMask(inSignalPin);
+		DCCppConfig::SignalPortInMain = portInputRegister(digitalPinToPort(inSignalPin));
 	}
 
-	if (inSignalPin != UNDEFINED_PIN)
-		pinMode(inSignalPin, OUTPUT); // FOR SHIELDS, THIS ARDUINO OUTPUT PIN MUST BE PHYSICALY CONNECTED TO THE PIN FOR DIRECTION-A OF MOTOR CHANNEL-A
+	pinMode(DCCppConfig::SignalEnablePinMain, OUTPUT); 
 
-	bitSet(TCCR1A, WGM10);     // set Timer 1 to FAST PWM, with TOP=OCR1A
-	bitSet(TCCR1A, WGM11);
-	bitSet(TCCR1B, WGM12);
-	bitSet(TCCR1B, WGM13);
+	/*
+	 Use the platform's timer2
+	 The timer2 has an 8 bit counter
+	 Presclaler = 8 to scale down the 16MHz Arduino processor frequency so that we can use an
+	 8bit counter. We need to interrupt every 58us. The frequency of interrupt is thus 
+	 1.000.000 / 58 = 17241 = 17,241kHz = f
+	 So values are:
+	 TCCR2A = 1 << WGM21; Set the TCM mode "Clear Timer on Compare Match"
+	 TCCR2B: CS22 = 0; CS21 = 1; CS20 = 0 <- prescaler = 8
+	 OCR2A = 115; The frequency of the interrupt, OCR2A = 16MHz / (f * prescaler) - 1
+	              so in our case (16.000.000 / (17.241 * 8 )) - 1
+	 TIMSK2 = 1 << OCIE2A; Enable timer compare interrupt
+	*/
 
-	bitSet(TCCR1A, COM1B1);    // set Timer 1, OC1B (pin 10/UNO, pin 12/MEGA) to inverting toggle (actual direction is arbitrary)
-	bitSet(TCCR1A, COM1B0);
+	noInterrupts();
 
-	bitClear(TCCR1B, CS12);    // set Timer 1 prescale=1
-	bitClear(TCCR1B, CS11);
-	bitSet(TCCR1B, CS10);
+	TCCR2A = 1 << WGM21; // CTC
+    TCCR2B = (0 << CS22) | (1 << CS21) | (0 << CS20); // prescale 8
 
-	OCR1A = DCC_ONE_BIT_TOTAL_DURATION_TIMER1;
-	OCR1B = DCC_ONE_BIT_PULSE_DURATION_TIMER1;
+	OCR2A = 115;              // Gives interrupt every 58us (for 16 Mhz)
+	bitSet  (TIMSK2, OCIE2A); // enable interrupt
 
-	pinMode(DCCppConfig::SignalEnablePinMain, OUTPUT);   // master enable for motor channel A
+	interrupts();
+
 
 	mainRegs.loadPacket(1, RegisterList::idlePacket, 2, 0);    // load idle packet into register 1    
 
-	bitSet(TIMSK1, OCIE1B);    // enable interrupt vector for Timer 1 Output Compare B Match (OCR1B)    
 	digitalWrite(DCCppConfig::SignalEnablePinMain, LOW);
 
 #ifdef DCCPP_DEBUG_MODE
@@ -179,9 +173,8 @@ void DCCpp::beginMain(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uin
 #endif
 }
 
-void DCCpp::beginProg(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uint8_t inSignalEnable, uint8_t inCurrentMonitor)
+void DCCpp::beginProg(uint8_t inSignalPin, uint8_t inSignalEnable, uint8_t inCurrentMonitor)
 {
-	DCCppConfig::DirectionMotorB = inOptionalDirectionMotor;
 	DCCppConfig::SignalEnablePinProg = inSignalEnable;
 	DCCppConfig::CurrentMonitorProg = inCurrentMonitor;
 
@@ -196,94 +189,27 @@ void DCCpp::beginProg(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uin
 
 	progMonitor.begin(DCCppConfig::CurrentMonitorProg, DCCppConfig::SignalEnablePinProg, (char *) "<p3>");
 
-	// CONFIGURE EITHER TIMER_0 (UNO) OR TIMER_3 (MEGA) TO OUTPUT 50% DUTY CYCLE DCC SIGNALS ON OC0B (UNO) OR OC3B (MEGA) INTERRUPT PINS
-
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO)      // Configuration for UNO
-
-	// Direction Pin for Motor Shield Channel B - PROGRAMMING TRACK
-	// Controlled by Arduino 8-bit TIMER 0 / OC0B Interrupt Pin
-	// Values for 8-bit OCR0A and OCR0B registers calibrated for 1:64 prescale at 16 MHz clock frequency
-	// Resulting waveforms are 200 microseconds for a ZERO bit and 116 microseconds for a ONE bit with as-close-as-possible to 50% duty cycle
-
-#define DCC_ZERO_BIT_TOTAL_DURATION_TIMER0 49
-#define DCC_ZERO_BIT_PULSE_DURATION_TIMER0 24
-
-#define DCC_ONE_BIT_TOTAL_DURATION_TIMER0 28
-#define DCC_ONE_BIT_PULSE_DURATION_TIMER0 14
-
-	if (DCCppConfig::DirectionMotorB != UNDEFINED_PIN)
-	{
-		pinMode(DCCppConfig::DirectionMotorB, INPUT);      // ensure this pin is not active! Direction will be controlled by DCC SIGNAL instead (below)
-		digitalWrite(DCCppConfig::DirectionMotorB, LOW);
+	if (inSignalPin != UNDEFINED_PIN) {
+		pinMode(inSignalPin, OUTPUT); 
+		DCCppConfig::SignalPortMaskProg = digitalPinToBitMask(inSignalPin);
+		DCCppConfig::SignalPortInProg = portInputRegister(digitalPinToPort(inSignalPin));
 	}
 
-	if (inSignalPin != UNDEFINED_PIN)
-		pinMode(inSignalPin, OUTPUT);      // THIS ARDUINO OUTPUT PIN MUST BE PHYSICALY CONNECTED TO THE PIN FOR DIRECTION-B OF MOTOR CHANNEL-B
 
-	bitSet(TCCR0A, WGM00);     // set Timer 0 to FAST PWM, with TOP=OCR0A
-	bitSet(TCCR0A, WGM01);
-	bitSet(TCCR0B, WGM02);
+	pinMode(DCCppConfig::SignalEnablePinProg, OUTPUT); 
 
-	bitSet(TCCR0A, COM0B1);    // set Timer 0, OC0B (pin 5) to inverting toggle (actual direction is arbitrary)
-	bitSet(TCCR0A, COM0B0);
+	// same code as in beginMain, it uses the same timer2.
+	noInterrupts();
 
-	bitClear(TCCR0B, CS02);    // set Timer 0 prescale=64
-	bitSet(TCCR0B, CS01);
-	bitSet(TCCR0B, CS00);
+	bitSet  (TCCR2A, WGM21);  // CTC
+	TCCR2A = 1 << WGM21; // CTC
+    TCCR2B = (0 << CS22) | (1 << CS21) | (0 << CS20); // prescale 8
+	OCR2A = 115;              // Gives interrupt every 58us (for 16 Mhz)
+	bitSet  (TIMSK2, OCIE2A); // enable interrupt
 
-	OCR0A = DCC_ONE_BIT_TOTAL_DURATION_TIMER0;
-	OCR0B = DCC_ONE_BIT_PULSE_DURATION_TIMER0;
-
-	pinMode(DCCppConfig::SignalEnablePinProg, OUTPUT);   // master enable for motor channel B
+	interrupts();
 
 	progRegs.loadPacket(1, RegisterList::idlePacket, 2, 0);    // load idle packet into register 1    
-
-	bitSet(TIMSK0, OCIE0B);    // enable interrupt vector for Timer 0 Output Compare B Match (OCR0B)
-
-#else      // Configuration for MEGA
-
-	// Direction Pin for Motor Shield Channel B - PROGRAMMING TRACK
-	// Controlled by Arduino 16-bit TIMER 3 / OC3B Interrupt Pin
-	// Values for 16-bit OCR3A and OCR3B registers calibrated for 1:1 prescale at 16 MHz clock frequency
-	// Resulting waveforms are 200 microseconds for a ZERO bit and 116 microseconds for a ONE bit with exactly 50% duty cycle
-
-#define DCC_ZERO_BIT_TOTAL_DURATION_TIMER3 3199
-#define DCC_ZERO_BIT_PULSE_DURATION_TIMER3 1599
-
-#define DCC_ONE_BIT_TOTAL_DURATION_TIMER3 1855
-#define DCC_ONE_BIT_PULSE_DURATION_TIMER3 927
-
-	if (DCCppConfig::DirectionMotorB != UNDEFINED_PIN)
-	{
-		pinMode(DCCppConfig::DirectionMotorB, INPUT);      // ensure this pin is not active! Direction will be controlled by DCC SIGNAL instead (below)
-		digitalWrite(DCCppConfig::DirectionMotorB, LOW);
-	}
-
-	pinMode(DCC_SIGNAL_PIN_PROG, OUTPUT);      // THIS ARDUINO OUTPUT PIN MUST BE PHYSICALLY CONNECTED TO THE PIN FOR DIRECTION-B OF MOTOR CHANNEL-B
-
-	bitSet(TCCR3A, WGM30);     // set Timer 3 to FAST PWM, with TOP=OCR3A
-	bitSet(TCCR3A, WGM31);
-	bitSet(TCCR3B, WGM32);
-	bitSet(TCCR3B, WGM33);
-
-	bitSet(TCCR3A, COM3B1);    // set Timer 3, OC3B (pin 2) to inverting toggle (actual direction is arbitrary)
-	bitSet(TCCR3A, COM3B0);
-
-	bitClear(TCCR3B, CS32);    // set Timer 3 prescale=1
-	bitClear(TCCR3B, CS31);
-	bitSet(TCCR3B, CS30);
-
-	OCR3A = DCC_ONE_BIT_TOTAL_DURATION_TIMER3;
-	OCR3B = DCC_ONE_BIT_PULSE_DURATION_TIMER3;
-
-	pinMode(DCCppConfig::SignalEnablePinProg, OUTPUT);   // master enable for motor channel B
-
-	progRegs.loadPacket(1, RegisterList::idlePacket, 2, 0);    // load idle packet into register 1    
-
-	bitSet(TIMSK3, OCIE3B);    // enable interrupt vector for Timer 3 Output Compare B Match (OCR3B)    
-
-#endif
-	digitalWrite(DCCppConfig::SignalEnablePinProg, LOW);
 
 #ifdef DCCPP_DEBUG_MODE
 	Serial.println(F("beginProg achivied"));
@@ -301,8 +227,8 @@ void DCCpp::begin()
 	DCCppConfig::SignalEnablePinProg = UNDEFINED_PIN;
 	DCCppConfig::CurrentMonitorProg = UNDEFINED_PIN;
 
-	DCCppConfig::DirectionMotorA = UNDEFINED_PIN;
-	DCCppConfig::DirectionMotorB = UNDEFINED_PIN;
+	DCCppConfig::SignalPortMaskMain = 0;
+	DCCppConfig::SignalPortMaskProg = 0;
 
 	mainMonitor.begin(UNDEFINED_PIN, UNDEFINED_PIN, "");
 	progMonitor.begin(UNDEFINED_PIN, UNDEFINED_PIN, "");
@@ -313,7 +239,7 @@ void DCCpp::begin()
 #endif
 
 #ifdef USE_EEPROM
-	EEStore::init();                                          // initialize and load Turnout and Sensor definitions stored in EEPROM
+	EEStore::init();     // initialize and load Turnout and Sensor definitions stored in EEPROM
 	if (EEStore::needsRefreshing())
 		EEStore::store();
 #endif
@@ -355,84 +281,76 @@ void DCCpp::beginEthernet(uint8_t *inMac, uint8_t *inIp, EthernetProtocol inProt
   // DEFINE THE INTERRUPT LOGIC THAT GENERATES THE DCC SIGNAL
   ///////////////////////////////////////////////////////////////////////////////
 
-  // The code below will be called every time an interrupt is triggered on OCNB, where N can be 0 or 1. 
+  // The code below will be called every time an timer interrupt is triggered. 
   // It is designed to read the current bit of the current register packet and
-  // updates the OCNA and OCNB counters of Timer-N to values that will either produce
-  // a long (200 microsecond) pulse, or a short (116 microsecond) pulse, which respectively represent
-  // DCC ZERO and DCC ONE bits.
+  // toggles the specified pin for a long (200 microsecond) or a short (116 microsecond) pulse,
+  // which respectively represent DCC ZERO and DCC ONE bits.
 
-  // These are hardware-driven interrupts that will be called automatically when triggered regardless of what
-  // DCC++ BASE STATION was otherwise processing.  But once inside the interrupt, all other interrupt routines are temporarily disabled.
-  // Since a short pulse only lasts for 116 microseconds, and there are TWO separate interrupts
-  // (one for Main Track Registers and one for the Program Track Registers), the interrupt code must complete
-  // in much less than 58 microseconds, otherwise there would be no time for the rest of the program to run.  Worse, if the logic
-  // of the interrupt code ever caused it to run longer than 58 microseconds, an interrupt trigger would be missed, the OCNA and OCNB
-  // registers would not be updated, and the net effect would be a DCC signal that keeps sending the same DCC bit repeatedly until the
-  // interrupt code completes and can be called again.
-
-  // A significant portion of this entire program is designed to do as much of the heavy processing of creating a properly-formed
-  // DCC bit stream upfront, so that the interrupt code below can be as simple and efficient as possible.
-
-  // Note that we need to create two very similar copies of the code --- one for the Main Track OC1B interrupt and one for the
-  // Programming Track OCOB interrupt.  But rather than create a generic function that incurs additional overhead, we create a macro
+  // Note that we need to create two very similar copies of the code --- one for the Main Track and one for the
+  // Programming Track.  But rather than create a generic function that incurs additional overhead, we create a macro
   // that can be invoked with proper parameters for each interrupt.  This slightly increases the size of the code base by duplicating
   // some of the logic for each interrupt, but saves additional time.
 
-  // As structured, the interrupt code below completes at an average of just under 6 microseconds with a worse-case of just under 11 microseconds
-  // when a new register is loaded and the logic needs to switch active register packet pointers.
+  // THE INTERRUPT CODE MACRO:  R=REGISTER LIST (mainRegs or progRegs), and N=Main or Prog postfix
 
-  // THE INTERRUPT CODE MACRO:  R=REGISTER LIST (mainRegs or progRegs), and N=TIMER (0 or 1)
-
-#define DCC_SIGNAL(R,N) \
-  if(R.currentBit==R.currentReg->activePacket->nBits){    /* IF no more bits in this DCC Packet */ \
-	R.currentBit=0;                                       /*   reset current bit pointer and determine which Register and Packet to process next--- */ \
-	if (R.nRepeat>0 && R.currentReg == R.reg) {               /*   IF current Register is first Register AND should be repeated */ \
-		R.nRepeat--;                                        /*     decrement repeat count; result is this same Packet will be repeated */ \
-	} \
-	else if (R.nextReg != NULL) {                           /*   ELSE IF another Register has been updated */ \
-		R.currentReg = R.nextReg;                             /*     update currentReg to nextReg */ \
-		R.nextReg = NULL;                                     /*     reset nextReg to NULL */ \
-		R.tempPacket = R.currentReg->activePacket;            /*     flip active and update Packets */ \
+#define DCC_NEXT_BIT(R) \
+	if(R.currentBit==R.currentReg->activePacket->nBits){  /* IF no more bits in this DCC Packet */ \
+	R.currentBit = 0;                                     /*   reset current bit pointer and determine which Register and Packet to process next--- */ \
+	if (R.nRepeat>0 && R.currentReg == R.reg){               /*   IF current Register is first Register AND should be repeated */ \
+		R.nRepeat--;                                      /*     decrement repeat count; result is this same Packet will be repeated */ \
+	}  \
+	else if (R.nextReg != NULL){                           /*   ELSE IF another Register has been updated */ \
+		R.currentReg = R.nextReg;                         /*     update currentReg to nextReg */ \
+		R.nextReg = NULL;                                 /*     reset nextReg to NULL */ \
+		R.tempPacket = R.currentReg->activePacket;        /*     flip active and update Packets */ \
 		R.currentReg->activePacket = R.currentReg->updatePacket; \
 		R.currentReg->updatePacket = R.tempPacket; \
 	} \
-	else {                                               /*   ELSE simply move to next Register */ \
-		if (R.currentReg == R.maxLoadedReg)                    /*     BUT IF this is last Register loaded */ \
-			R.currentReg = R.reg;                               /*       first reset currentReg to base Register, THEN */ \
-			R.currentReg++;                                     /*     increment current Register (note this logic causes Register[0] to be skipped when simply cycling through all Registers) */ \
-		}                                                     /*   END-ELSE */ \
-	}                                                       /* END-IF: currentReg, activePacket, and currentBit should now be properly set to point to next DCC bit */ \
-	\
-	if (R.currentReg->activePacket->buf[R.currentBit / 8] & R.bitMask[R.currentBit % 8]) {     /* IF bit is a ONE */ \
-		OCR ## N ## A = DCC_ONE_BIT_TOTAL_DURATION_TIMER ## N;                               /*   set OCRA for timer N to full cycle duration of DCC ONE bit */ \
-	OCR ## N ## B=DCC_ONE_BIT_PULSE_DURATION_TIMER ## N;                               /*   set OCRB for timer N to half cycle duration of DCC ONE but */ \
-  } else{                                                                              /* ELSE it is a ZERO */ \
-	OCR ## N ## A=DCC_ZERO_BIT_TOTAL_DURATION_TIMER ## N;                              /*   set OCRA for timer N to full cycle duration of DCC ZERO bit */ \
-	OCR ## N ## B=DCC_ZERO_BIT_PULSE_DURATION_TIMER ## N;                              /*   set OCRB for timer N to half cycle duration of DCC ZERO bit */ \
-  }                                                                                    /* END-ELSE */ \
-	\
-	R.currentBit++;     /* point to next bit in current Packet */
-
+	else {                                                /*   ELSE simply move to next Register */ \
+		if (R.currentReg == R.maxLoadedReg)                  /*     BUT IF this is last Register loaded */ \
+			R.currentReg = R.reg;                         /*       first reset currentReg to base Register, THEN */ \
+		R.currentReg++;                                   /*     increment current Register (note this logic causes Register[0] to be skipped when simply cycling through all Registers) */ \
+		}                                                 /*   END-ELSE */ \
+	}                                                     /* END-IF: currentReg, activePacket, and currentBit should now be properly set to point to next DCC bit */ \
+	if(R.currentReg->activePacket->buf[R.currentBit/8] & R.bitMask[R.currentBit%8]) {  \
+		/* For 1 bit, we need 1 periods of 58us timer ticks for each signal level */ \
+		R.timerPeriods = 1; \
+		R.timerPeriodsLeft = 2; \
+	} else {  /* ELSE it is a ZERO bit */ \
+		/* For 0 bit, we need 2 period of 58us timer ticks for each signal level. */ \
+		R.timerPeriods = 2; \
+		R.timerPeriodsLeft = 4; \
+	}         /* END-ELSE */ \
+	                         \
+	R.currentBit++;     /* point to next bit in current Packet */  
+  
 ///////////////////////////////////////////////////////////////////////////////
+
+/* 
+   For each bit, toggle pin twice: when timer counts to timerPeriods of
+   the register, and when timer counts to 0. Then next bit is activated.
+ */ 
+
+#define CHECK_TIMER_PERIOD(R,N)                    \
+	R.timerPeriodsLeft--;                          \
+	if(R.timerPeriodsLeft == R.timerPeriods) {     \
+		*DCCppConfig::SignalPortIn ## N = DCCppConfig::SignalPortMask ## N; \
+	}                                              \
+	if(R.timerPeriodsLeft == 0) {                  \
+		*DCCppConfig::SignalPortIn ## N = DCCppConfig::SignalPortMask ## N; \
+		DCC_NEXT_BIT(R);                           \
+	}                                              \
+
 // NOW USE THE ABOVE MACRO TO CREATE THE CODE FOR EACH INTERRUPT
 
-ISR(TIMER1_COMPB_vect) {              // set interrupt service for OCR1B of TIMER-1 which flips direction bit of Motor Shield Channel A controlling Main Track
-	DCC_SIGNAL(DCCpp::mainRegs, 1)
+ISR(TIMER2_COMPA_vect) { 
+	if(DCCppConfig::SignalPortMaskMain != 0)
+  		CHECK_TIMER_PERIOD(DCCpp::mainRegs, Main)
+  	if(DCCppConfig::SignalPortMaskProg != 0)
+  		CHECK_TIMER_PERIOD(DCCpp::progRegs, Prog)
+	//*DCCppConfig::SignalPortInMain = DCCppConfig::SignalPortMaskMain; 
 }
 
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO)      // Configuration for UNO
-
-ISR(TIMER0_COMPB_vect) {              // set interrupt service for OCR1B of TIMER-0 which flips direction bit of Motor Shield Channel B controlling Programming Track
-	DCC_SIGNAL(DCCpp::progRegs, 0)
-}
-
-#else      // Configuration for MEGA
-
-ISR(TIMER3_COMPB_vect) {              // set interrupt service for OCR3B of TIMER-3 which flips direction bit of Motor Shield Channel B controlling Programming Track
-	DCC_SIGNAL(DCCpp::progRegs, 3)
-}
-
-#endif
 
 #ifdef DCCPP_PRINT_DCCPP
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/DCCpp.h
+++ b/src/DCCpp.h
@@ -378,7 +378,7 @@ Main include file of the library.*/
 
 ////////////////////////////////////////////////////////
 // Add a '//' at the beginning of the line to be in production mode.
-#define DCCPP_DEBUG_MODE
+//#define DCCPP_DEBUG_MODE
 
 ///////////////////////////////////////////////////////
 // Verbose mode lets you see all actions done by the 
@@ -396,11 +396,11 @@ Main include file of the library.*/
 //
 
 #define USE_TURNOUT
-//#define USE_EEPROM
+#define USE_EEPROM
 #define USE_OUTPUT
 #define USE_SENSOR
 #define USE_TEXTCOMMAND
-//#define USE_ETHERNET_WIZNET_5100
+#define USE_ETHERNET_WIZNET_5100
 //#define USE_ETHERNET_WIZNET_5500
 //#define USE_ETHERNET_WIZNET_5200
 //#define USE_ETHERNET_ENC28J60

--- a/src/DCCpp.h
+++ b/src/DCCpp.h
@@ -378,7 +378,7 @@ Main include file of the library.*/
 
 ////////////////////////////////////////////////////////
 // Add a '//' at the beginning of the line to be in production mode.
-//#define DCCPP_DEBUG_MODE
+#define DCCPP_DEBUG_MODE
 
 ///////////////////////////////////////////////////////
 // Verbose mode lets you see all actions done by the 
@@ -396,11 +396,11 @@ Main include file of the library.*/
 //
 
 #define USE_TURNOUT
-#define USE_EEPROM
+//#define USE_EEPROM
 #define USE_OUTPUT
 #define USE_SENSOR
 #define USE_TEXTCOMMAND
-#define USE_ETHERNET_WIZNET_5100
+//#define USE_ETHERNET_WIZNET_5100
 //#define USE_ETHERNET_WIZNET_5500
 //#define USE_ETHERNET_WIZNET_5200
 //#define USE_ETHERNET_ENC28J60

--- a/src/DCCpp.hpp
+++ b/src/DCCpp.hpp
@@ -106,17 +106,17 @@ class DCCpp
 
 		/** Initializes the main track for an Arduino Motor Shield.
 		*/
-		static inline void beginMainMotorShield() { beginMain(DCC_SIGNAL_PIN_MAIN, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_MAIN, MOTOR_SHIELD_CURRENT_MONITOR_PIN_MAIN); }
+		static inline void beginMainMotorShield() { beginMain(MOTOR_SHIELD_DIRECTION_MOTOR_CHANNEL_PIN_A, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_MAIN, MOTOR_SHIELD_CURRENT_MONITOR_PIN_MAIN); }
 		/** Initializes the programming track for an Arduino Motor Shield.
 		*/
-		static inline void beginProgMotorShield() { beginProg(DCC_SIGNAL_PIN_PROG, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_PROG, MOTOR_SHIELD_CURRENT_MONITOR_PIN_PROG); }
+		static inline void beginProgMotorShield() { beginProg(MOTOR_SHIELD_DIRECTION_MOTOR_CHANNEL_PIN_B, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_PROG, MOTOR_SHIELD_CURRENT_MONITOR_PIN_PROG); }
 
 		/** Initializes the main track for a Pololu MC33926 Motor Shield.
 		*/
-		static inline void beginMainPololu() { beginMain(DCC_SIGNAL_PIN_MAIN, POLOLU_SIGNAL_ENABLE_PIN_MAIN, POLOLU_CURRENT_MONITOR_PIN_MAIN); }
+		static inline void beginMainPololu() { beginMain(POLOLU_DIRECTION_MOTOR_CHANNEL_PIN_A, POLOLU_SIGNAL_ENABLE_PIN_MAIN, POLOLU_CURRENT_MONITOR_PIN_MAIN); }
 		/** Initializes the programming track for a Pololu MC33926 Motor Shield.
 		*/
-		static inline void beginProgPololu() { beginProg(DCC_SIGNAL_PIN_PROG, POLOLU_SIGNAL_ENABLE_PIN_PROG, POLOLU_CURRENT_MONITOR_PIN_PROG); }
+		static inline void beginProgPololu() { beginProg(POLOLU_DIRECTION_MOTOR_CHANNEL_PIN_B, POLOLU_SIGNAL_ENABLE_PIN_PROG, POLOLU_CURRENT_MONITOR_PIN_PROG); }
 #ifdef USE_ETHERNET
 		/** Initializes the Ethernet link.
 		@param inMac Mac address of this network element.

--- a/src/DCCpp.hpp
+++ b/src/DCCpp.hpp
@@ -95,28 +95,28 @@ class DCCpp
 		@param inSignalEnablePin	Pin for the enable/PWM pin, set it to UNDEFINED_PIN if not used.
 		@param inCurrentMonitor	Pin for the current monitor analog pin, set it to UNDEFINED_PIN if not used.
 		*/
-		static void beginMain(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uint8_t inSignalEnablePin, uint8_t inCurrentMonitor);
+		static void beginMain(uint8_t inSignalPin, uint8_t inSignalEnablePin, uint8_t inCurrentMonitor);
 		/** Initializes the programming track.
 		@param inOptionalDirectionMotor	Pin for the rerouting of shields direction pin, set it to UNDEFINED_PIN if not used.
 		@param inSignalPin	Pin for the signal pin, the one driven by an interruption, set it to UNDEFINED_PIN if not used (but the line will be always down...).
 		@param inSignalEnablePin	Pin for the enable/PWM pin, set it to UNDEFINED_PIN if not used.
 		@param inCurrentMonitor	Pin for the current monitor analog pin, set it to UNDEFINED_PIN if not used.
 		*/
-		static void beginProg(uint8_t inOptionalDirectionMotor, uint8_t inSignalPin, uint8_t inSignalEnablePin, uint8_t inCurrentMonitor);
+		static void beginProg(uint8_t inSignalPin, uint8_t inSignalEnablePin, uint8_t inCurrentMonitor);
 
 		/** Initializes the main track for an Arduino Motor Shield.
 		*/
-		static inline void beginMainMotorShield() { beginMain(MOTOR_SHIELD_DIRECTION_MOTOR_CHANNEL_PIN_A, DCC_SIGNAL_PIN_MAIN, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_MAIN, MOTOR_SHIELD_CURRENT_MONITOR_PIN_MAIN); }
+		static inline void beginMainMotorShield() { beginMain(DCC_SIGNAL_PIN_MAIN, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_MAIN, MOTOR_SHIELD_CURRENT_MONITOR_PIN_MAIN); }
 		/** Initializes the programming track for an Arduino Motor Shield.
 		*/
-		static inline void beginProgMotorShield() { beginProg(MOTOR_SHIELD_DIRECTION_MOTOR_CHANNEL_PIN_B, DCC_SIGNAL_PIN_PROG, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_PROG, MOTOR_SHIELD_CURRENT_MONITOR_PIN_PROG); }
+		static inline void beginProgMotorShield() { beginProg(DCC_SIGNAL_PIN_PROG, MOTOR_SHIELD_SIGNAL_ENABLE_PIN_PROG, MOTOR_SHIELD_CURRENT_MONITOR_PIN_PROG); }
 
 		/** Initializes the main track for a Pololu MC33926 Motor Shield.
 		*/
-		static inline void beginMainPololu() { beginMain(POLOLU_DIRECTION_MOTOR_CHANNEL_PIN_A, DCC_SIGNAL_PIN_MAIN, POLOLU_SIGNAL_ENABLE_PIN_MAIN, POLOLU_CURRENT_MONITOR_PIN_MAIN); }
+		static inline void beginMainPololu() { beginMain(DCC_SIGNAL_PIN_MAIN, POLOLU_SIGNAL_ENABLE_PIN_MAIN, POLOLU_CURRENT_MONITOR_PIN_MAIN); }
 		/** Initializes the programming track for a Pololu MC33926 Motor Shield.
 		*/
-		static inline void beginProgPololu() { beginProg(POLOLU_DIRECTION_MOTOR_CHANNEL_PIN_B, DCC_SIGNAL_PIN_PROG, POLOLU_SIGNAL_ENABLE_PIN_PROG, POLOLU_CURRENT_MONITOR_PIN_PROG); }
+		static inline void beginProgPololu() { beginProg(DCC_SIGNAL_PIN_PROG, POLOLU_SIGNAL_ENABLE_PIN_PROG, POLOLU_CURRENT_MONITOR_PIN_PROG); }
 #ifdef USE_ETHERNET
 		/** Initializes the Ethernet link.
 		@param inMac Mac address of this network element.

--- a/src/PacketRegister.cpp
+++ b/src/PacketRegister.cpp
@@ -29,8 +29,11 @@ byte DCCppConfig::CurrentMonitorMain = UNDEFINED_PIN;
 byte DCCppConfig::SignalEnablePinProg = UNDEFINED_PIN;
 byte DCCppConfig::CurrentMonitorProg = UNDEFINED_PIN;
 					
-byte DCCppConfig::DirectionMotorA = UNDEFINED_PIN;
-byte DCCppConfig::DirectionMotorB = UNDEFINED_PIN;
+uint8_t	DCCppConfig::SignalPortMaskMain = 0;
+uint8_t	DCCppConfig::SignalPortMaskProg = 0;
+
+volatile uint8_t *DCCppConfig::SignalPortInMain = 0;
+volatile uint8_t *DCCppConfig::SignalPortInProg = 0;
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/PacketRegister.h
+++ b/src/PacketRegister.h
@@ -42,6 +42,11 @@ struct RegisterList{
   Register *maxLoadedReg;
   Register *nextReg;
   Packet  *tempPacket;
+  /* how many 58us periods needed for half-cycle (1 for "1", 2 for "0") */
+  byte timerPeriods;
+  /* how many 58us periods are left (at start, 2 for "1", 4 for "0"). */
+  byte timerPeriodsLeft;
+
   byte currentBit;
   byte nRepeat;
   int *speedTable;


### PR DESCRIPTION
A pull request to implement https://github.com/Locoduino/DCCpp/issues/3.

This change gets rid of 2 timers and uses only Timer2 to tick every 58us and change logic levels on both tracks. Zero bit is changed every 2 ticks, "one" bit changes every tick; this makes timings roughly equal to DCC specs. 

This frees one timer and 2 pins to be used for something else, though PWM pins controlled by Timer2 cannot be used for hardware-PWM (they can, however, be used to output DCC signal using proposed method since it is effectively a software-PWM). Jumpers for shields are not needed anymore. This is done at the RAM cost of 2 bytes per RegisterList and 2 extra pointers in DCCppConfig (pointers might not be needed, they are used for direct IO port manipulation to bypass arduino's digitalWrite).

I've tested it on Arduino Nano and Arduino Uno with 2 different LaisDCC decoders. I've used chineese L298 board with custom-added current-sensing resistors, it works well. Unfortunately, I cannot test with Arduino Mega.

I've changed SerialDCC and Autotest examples to match new interface but retain pin compatibility. MiniDCC and MaxiDCC I cannot compile (do not have library with Controllers.h) and they were not modified.